### PR TITLE
Fixed link to ENSEMBL site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ensembl-data
-Mirror of GTF and FASTA data from the [Ensembl](www.ensembl.org) FTP servers.
+Mirror of GTF and FASTA data from the [Ensembl](https://www.ensembl.org) FTP servers.
 
 Each supported species (so far just human and mouse) has a Github release in this repository corresponding to a release of Ensembl. The release has the following attached files: 
   * GTF contains genes, transcripts, and exons


### PR DESCRIPTION
Current link to ENSEMBL site is broken, this pull request fixing it to https://ensembl.org